### PR TITLE
Add image upload to event admin form

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,11 @@ const nextConfig: NextConfig = {
         hostname: "scontent-sjc3-1.xx.fbcdn.net",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "*.public.blob.vercel-storage.com",
+        pathname: "/**",
+      },
     ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hacksl-site",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/blob": "^2.4.0",
         "@vercel/postgres": "^0.10.0",
         "next": "16.1.6",
         "nodemailer": "^6.10.1",
@@ -2171,6 +2172,22 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@vercel/postgres": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@vercel/postgres/-/postgres-0.10.0.tgz",
@@ -2434,6 +2451,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -4109,6 +4135,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -4280,6 +4329,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -5719,6 +5774,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6267,6 +6331,18 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6519,6 +6595,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@vercel/blob": "^2.4.0",
     "@vercel/postgres": "^0.10.0",
     "next": "16.1.6",
     "nodemailer": "^6.10.1",

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { BlogPost } from "@/lib/blog-types";
 import type { Hackathon } from "@/lib/hackathon-types";
 
@@ -103,6 +103,8 @@ export default function AdminPage() {
     tags: [],
   });
   const [tagInput, setTagInput] = useState("");
+  const [imageUploading, setImageUploading] = useState(false);
+  const imageFileRef = useRef<HTMLInputElement>(null);
   const [blogs, setBlogs] = useState<BlogPost[]>([]);
   const [blogForm, setBlogForm] = useState<Partial<BlogPost>>({
     title: "",
@@ -148,6 +150,30 @@ export default function AdminPage() {
       ...f,
       tags: (f.tags || []).filter((_, idx) => idx !== i),
     }));
+  };
+
+  const handleImageFile = async (file: File) => {
+    setImageUploading(true);
+    setMessage(null);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/api/admin/upload", {
+        method: "POST",
+        credentials: "include",
+        body: fd,
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setMessage({ type: "err", text: data.error || "Upload failed" });
+        return;
+      }
+      setForm((f) => ({ ...f, image: data.url }));
+    } catch {
+      setMessage({ type: "err", text: "Upload failed" });
+    } finally {
+      setImageUploading(false);
+    }
   };
 
   const submit = async (e: React.FormEvent) => {
@@ -386,13 +412,51 @@ export default function AdminPage() {
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium text-[var(--foreground)]">Image URL (optional)</label>
-              <input
-                value={form.image ?? ""}
-                onChange={(e) => setForm((f) => ({ ...f, image: e.target.value || undefined }))}
-                placeholder="/image.png or https://..."
-                className="mt-1 w-full rounded-lg border border-[var(--border)] px-3 py-2"
-              />
+              <label className="block text-sm font-medium text-[var(--foreground)]">Event Image (optional)</label>
+              <div className="mt-1 space-y-2">
+                <label
+                  className={`flex cursor-pointer items-center justify-center gap-2 rounded-lg border-2 border-dashed border-[var(--border)] px-3 py-3 text-sm text-[var(--muted)] transition hover:border-[var(--accent)] hover:text-[var(--accent)] ${imageUploading ? "opacity-60 pointer-events-none" : ""}`}
+                >
+                  <input
+                    ref={imageFileRef}
+                    type="file"
+                    accept="image/*"
+                    className="sr-only"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) handleImageFile(file);
+                    }}
+                  />
+                  {imageUploading ? "Uploading…" : "Upload image"}
+                </label>
+                <input
+                  value={form.image ?? ""}
+                  onChange={(e) => setForm((f) => ({ ...f, image: e.target.value || undefined }))}
+                  placeholder="or paste URL: /image.png or https://..."
+                  className="w-full rounded-lg border border-[var(--border)] px-3 py-2 text-sm"
+                />
+                {form.image && (
+                  <div className="relative">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={form.image}
+                      alt="preview"
+                      className="h-24 w-full rounded-lg object-cover"
+                      onError={(e) => (e.currentTarget.style.display = "none")}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setForm((f) => ({ ...f, image: undefined }));
+                        if (imageFileRef.current) imageFileRef.current.value = "";
+                      }}
+                      className="absolute right-1 top-1 rounded-full bg-black/50 px-1.5 py-0.5 text-xs text-white hover:bg-black/70"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
           <div className="grid gap-4 sm:grid-cols-2">

--- a/src/app/api/admin/upload/route.ts
+++ b/src/app/api/admin/upload/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { put } from "@vercel/blob";
+import { verifySessionToken, getSessionCookieName } from "@/lib/auth";
+
+function isAuthenticated(request: NextRequest): boolean {
+  const sessionToken = request.cookies.get(getSessionCookieName())?.value;
+  if (sessionToken && verifySessionToken(sessionToken)) return true;
+  const authHeader = request.headers.get("authorization");
+  const adminSecret = process.env.HACKSL_ADMIN_SECRET || "hacksl-admin-2025";
+  if (authHeader && authHeader === `Bearer ${adminSecret}`) return true;
+  return false;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthenticated(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const form = await request.formData();
+  const file = form.get("file") as File | null;
+  if (!file) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  const allowed = ["image/jpeg", "image/png", "image/webp", "image/gif", "image/svg+xml"];
+  if (!allowed.includes(file.type)) {
+    return NextResponse.json({ error: "Unsupported file type" }, { status: 400 });
+  }
+
+  if (file.size > 5 * 1024 * 1024) {
+    return NextResponse.json({ error: "File too large (max 5 MB)" }, { status: 400 });
+  }
+
+  const blob = await put(`hackathons/${Date.now()}-${file.name}`, file, {
+    access: "public",
+  });
+
+  return NextResponse.json({ url: blob.url });
+}


### PR DESCRIPTION
## Summary
- Admins can now upload an image file directly in the hackathon/event form via Vercel Blob storage
- A clickable dashed upload zone is shown, with a live preview and a remove button once an image is set
- The existing URL paste field is kept as a fallback for external images
- Accepted formats: JPEG, PNG, WebP, GIF, SVG (max 5 MB)
- New upload API at POST /api/admin/upload protected by the same session auth as other admin routes
- Added *.public.blob.vercel-storage.com to next.config.ts remote image patterns

## One-time setup required
Add the BLOB_READ_WRITE_TOKEN environment variable in your Vercel project settings (Storage → Blob → Connect Store). Without it, the upload endpoint will throw at runtime.

## Test plan
- [ ] Log in to /admin, create a new event, click "Upload image", pick a local image file — verify it appears as a preview
- [ ] Submit the form — verify the event card on the home page shows the uploaded image
- [ ] Paste a URL into the URL field — verify the preview updates accordingly
- [ ] Click X to clear the image — verify the preview disappears
- [ ] Try uploading a >5 MB file — verify an error message is shown

Generated with Claude Code